### PR TITLE
New API (1.21.1) player head texture from base64 fix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Added support for the new API (1.21.1) to enable adding player heads with base64 textures in new engine versions.

![image](https://github.com/user-attachments/assets/4fbb41e3-946b-41f8-827e-ae74252eb2ed)
