### PR TITLE
Add missing Aikar repository + cancel moving event from hotbar + PDC locking mechanism to avoid PvP/TP Bow item moving

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fun.lewisdev</groupId>
     <artifactId>DeluxeHubReloaded</artifactId>
-    <version>3.6.11</version>
+    <version>3.6.12</version>
     <packaging>jar</packaging>
 
     <name>DeluxeHubReloaded</name>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,10 @@
             <id>opencollab-snapshot</id>
             <url>https://repo.opencollab.dev/main/</url>
         </repository>
+        <repository>
+            <id>aikar</id>
+            <url>https://repo.aikar.co/content/groups/aikar/</url>
+        </repository>
     </repositories>
 
     <dependencies>

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/HotbarItem.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/HotbarItem.java
@@ -146,7 +146,8 @@ public abstract class HotbarItem implements Listener {
 			String hotbarItem = meta.getPersistentDataContainer().get(new NamespacedKey(getPlugin(), "hotbarItem"), PersistentDataType.STRING);
 			if (hotbarItem != null && getHotbarManager().inDisabledWorld(player.getLocation()) && hotbarItem.equals(key)) return;
 			else if (hotbarItem != null && hotbarItem.equals(key)) {
-				onInteract(player);
+				onInteract(player); // Do the action related to that item like opening a server menu
+                                event.setCancelled(true); // Let the menu/action to be completed but cancel any item movements
 			}
 		}
 	}

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/HotbarItem.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/HotbarItem.java
@@ -147,7 +147,7 @@ public abstract class HotbarItem implements Listener {
 			if (hotbarItem != null && getHotbarManager().inDisabledWorld(player.getLocation()) && hotbarItem.equals(key)) return;
 			else if (hotbarItem != null && hotbarItem.equals(key)) {
 				onInteract(player); // Do the action related to that item like opening a server menu
-                                event.setCancelled(true); // Let the menu/action to be completed but cancel any item movements
+                                if (allowMovement) event.setCancelled(true); // Let the menu/action to be completed but cancel any item movements
 			}
 		}
 	}

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/HotbarManager.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/HotbarManager.java
@@ -44,19 +44,10 @@ public class HotbarManager extends Module {
 			_joinSlot = config.getInt("hotbar.slot_number");
 		}
                 
-                // Create a dummy item and register the HotbarItem
-                ItemStack dummyItem = new ItemStack(Material.STICK);
-                /*ItemMeta meta = dummyItem.getItemMeta();
-                
-                if (meta != null) {
-                    meta.setDisplayName("Dummy Item");
-                    dummyItem.setItemMeta(meta);
-                }*/
-                
+                // Create a dummy item and register it. Used to protect any hotbar items to be moved inside containers like decorated pots.
+                ItemStack dummyItem = new ItemStack(Material.STICK);                
                 CustomItem customItemDef = new CustomItem(this, dummyItem, 0, "Hotbar Item Locker");
-                
                 Bukkit.getPluginManager().registerEvents(customItemDef, getPlugin());
-                //registerHotbarItem(customItemDef);
 
 		if (config.getBoolean("custom_join_items.enabled")) {
 

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/HotbarManager.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/HotbarManager.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.bukkit.Material;
 
 public class HotbarManager extends Module {
 
@@ -42,6 +43,20 @@ public class HotbarManager extends Module {
 		if (config.getBoolean("hotbar.joinslot")) {
 			_joinSlot = config.getInt("hotbar.slot_number");
 		}
+                
+                // Create a dummy item and register the HotbarItem
+                ItemStack dummyItem = new ItemStack(Material.STICK);
+                /*ItemMeta meta = dummyItem.getItemMeta();
+                
+                if (meta != null) {
+                    meta.setDisplayName("Dummy Item");
+                    dummyItem.setItemMeta(meta);
+                }*/
+                
+                CustomItem customItemDef = new CustomItem(this, dummyItem, 0, "Hotbar Item Locker");
+                
+                Bukkit.getPluginManager().registerEvents(customItemDef, getPlugin());
+                //registerHotbarItem(customItemDef);
 
 		if (config.getBoolean("custom_join_items.enabled")) {
 

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/player/PvPMode.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/player/PvPMode.java
@@ -81,6 +81,7 @@ public class PvPMode extends Module {
 			_switcher.put(state,
 					ItemStackBuilder.getItemStack(switcherSection)
 							.addPartialData(section)
+							.addNamespacedKey(new org.bukkit.NamespacedKey(getPlugin(), "hotbarItem"), PersistentDataType.STRING, "Hotbar Item Locker")
 							.addNamespacedKey(NamespacedKeys.Keys.PVP_MODE_SWITCHER.get(), PersistentDataType.BOOLEAN, true)
 							.addNamespacedKey(NamespacedKeys.Keys.PVP_MODE_SWITCHER_STATE.get(), PersistentDataType.BOOLEAN, state != PvPSwitcherState.PVP_OFF).build());
         }
@@ -99,6 +100,7 @@ public class PvPMode extends Module {
 								otherItemSection.set(entry.getKey(), entry.getValue());
 							}
 							ItemStack item = ItemStackBuilder.getItemStack(otherItemSection)
+                                                                        .addNamespacedKey(new org.bukkit.NamespacedKey(getPlugin(), "hotbarItem"), PersistentDataType.STRING, "Hotbar Item Locker")
 									.addNamespacedKey(NamespacedKeys.Keys.PVP_MODE_ITEM.get(), PersistentDataType.BOOLEAN, true).build();
 							_items.get(type).add(item);
 						}
@@ -108,6 +110,7 @@ public class PvPMode extends Module {
 			}
 			List<ItemStack> itemList = new ArrayList<>();
 			itemList.add(ItemStackBuilder.getItemStack(section)
+                                .addNamespacedKey(new org.bukkit.NamespacedKey(getPlugin(), "hotbarItem"), PersistentDataType.STRING, "Hotbar Item Locker")
 				.addNamespacedKey(NamespacedKeys.Keys.PVP_MODE_ITEM.get(), PersistentDataType.BOOLEAN, true).build());
 			_items.put(type, itemList);
 		}

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/player/TeleportationBow.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/player/TeleportationBow.java
@@ -80,6 +80,7 @@ public class TeleportationBow extends Module {
                         null)
 				.setUnbreakable(true)
 				.withEnchantment(Enchantment.INFINITY)
+                .addNamespacedKey(new org.bukkit.NamespacedKey(getPlugin(), "hotbarItem"), PersistentDataType.STRING, "Hotbar Item Locker")
                 .addNamespacedKey(NamespacedKeys.Keys.TELEPORTATION_BOW_ITEM.get(), PersistentDataType.BOOLEAN, true)
                 .build();
 		if(arrowSection == null){
@@ -89,6 +90,7 @@ public class TeleportationBow extends Module {
 				getItemStack(arrowItem,
 						arrowSection,
 						null)
+				.addNamespacedKey(new org.bukkit.NamespacedKey(getPlugin(), "hotbarItem"), PersistentDataType.STRING, "Hotbar Item Locker")
 				.addNamespacedKey(NamespacedKeys.Keys.TELEPORTATION_BOW_ITEM.get(), PersistentDataType.BOOLEAN, true)
 				.build();
         if(config.getBoolean("disable_inventory_movement")){


### PR DESCRIPTION
- Adding a missing repository from Aikar (needed for the dependency "acf-paper")


From this request on Discord : https://discord.com/channels/1269771579483750440/1327682649505927192
- Adding "event.setCancelled(true);" in function "hotbarItemInteract(PlayerInteractEvent event)" if this is a known hotbar item and "disable_inventory_movement" is true.
- Adding a "locking mechanism" for non standard hotbar items (PvP mode items and TP Bow items).
=> To have a "known" key, a dummy item is generated without being given to any users. This is only used to call the constructor and register the "key" value.