### PR TITLE
Add null check during PvP item iterator

### DIFF
--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/player/PvPMode.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/player/PvPMode.java
@@ -162,6 +162,7 @@ public class PvPMode extends Module {
 							inv.setItem(_slot, _switcher.get(PvPSwitcherState.PVP_ON));
 							for (PvPItemType itemType : PvPItemType.values()) {
 								List<ItemStack> is = _items.get(itemType);
+								if (is == null) continue;
 								switch (itemType) {
 									case SWORD:
 										short slot = (short) itemType.getSlot();
@@ -183,15 +184,16 @@ public class PvPMode extends Module {
 									case BOOTS:
 										inv.setBoots(is.get(0));
 										break;
-									default:{
-										for(ItemStack item : is)
+									default:
+										for(ItemStack item : is){
 											for(int i = 0; i < 9; i++){
 												if(inv.getItem(i) == null){
 													inv.setItem(i, item);
 													break;
 												}
 											}
-									}
+										}
+										break;
 								}
 							}
 							inv.clear(_slot);


### PR DESCRIPTION
`[02:55:58 WARN]: [DeluxeHubReloaded] Task #24077 for DeluxeHubReloaded v3.6.12 generated an exception
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "is" is null
        at DeluxeHubReloaded-3.6.12.jar/fun.lewisdev.deluxehub.module.modules.player.PvPMode$1.run(PvPMode.java:187) ~[DeluxeHubReloaded-3.6.12.jar:?]`
Prevents the exception from being thrown, when PvPItemTypes are removed from config (for example, removing the "OTHER" items, etc).