### PR TITLE
Fix flight bug and sound bug (or error messages)

### DIFF
--- a/src/main/java/fun/lewisdev/deluxehub/action/actions/SoundAction.java
+++ b/src/main/java/fun/lewisdev/deluxehub/action/actions/SoundAction.java
@@ -17,7 +17,17 @@ public class SoundAction implements Action {
 	@Override
 	public void execute(DeluxeHubPlugin plugin, Player player, String data) {
 		try {
-			player.playSound(player.getLocation(), Registry.SOUNDS.getOrThrow(NamespacedKey.minecraft(data.toLowerCase().replaceFirst("^_", ".").replaceFirst("_$", ".").replaceAll("_(?=.*_)", "."))), 1L, 1L);
+			String soundName = data.toUpperCase().replace(".", "_");
+
+			// Try, to get the Sound
+			Object sound;
+			try {
+				sound = Enum.valueOf((Class<Enum>) Class.forName("org.bukkit.Sound"), soundName);
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException("Bukkit Sound class not found!", e);
+			}
+
+			player.playSound(player.getLocation(), (org.bukkit.Sound) sound, 1.0F, 1.0F);
 		} catch (Exception ex) {
 			Bukkit.getLogger().warning("[DeluxeHub Action] Invalid sound name: " + data.toUpperCase());
 		}

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/FlyCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/FlyCommand.java
@@ -9,6 +9,7 @@ import fun.lewisdev.deluxehub.config.Messages;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerJoinEvent;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/FlyCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/FlyCommand.java
@@ -31,7 +31,7 @@ public class FlyCommand {
 	public void flight(final CommandContext args, final CommandSender sender) throws CommandException {
 
 		if (args.argsLength() == 0) {
-			if (!(sender instanceof Player)) throw new CommandException("Console cannot clear inventory");
+			if (!(sender instanceof Player)) throw new CommandException("Console cannot toggle flight mode.");
 
 			if (!(sender.hasPermission(Permissions.COMMAND_FLIGHT.getPermission()))) {
 				Messages.NO_PERMISSION.send(sender);
@@ -39,7 +39,7 @@ public class FlyCommand {
 			}
 
 			Player player = (Player) sender;
-			if (allowPlayerFly.putIfAbsent(player.getUniqueId(), false) == null) ;
+			allowPlayerFly.putIfAbsent(player.getUniqueId(), false);
 			if (allowPlayerFly.get(player.getUniqueId())) {
 				Messages.FLIGHT_DISABLE.send(player);
 				toggleFlight(player, false);

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/FlyCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/FlyCommand.java
@@ -43,7 +43,7 @@ public class FlyCommand {
 				Messages.FLIGHT_DISABLE.send(player);
 				toggleFlight(player, false);
 				allowPlayerFly.put(player.getUniqueId(), false);
-				player.setAllowFlight(true);
+				// Removed player.setAllowFlight(true) to prevent re-enabling flight
 			} else {
 				Messages.FLIGHT_ENABLE.send(player);
 				toggleFlight(player, true);

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/player/PlayerListener.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/player/PlayerListener.java
@@ -16,6 +16,7 @@ import org.bukkit.entity.Firework;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -88,7 +89,7 @@ public class PlayerListener extends Module {
 	public void onPlayerJoin(PlayerJoinEvent event) {
 		Player player = event.getPlayer();
 		if (inDisabledWorld(player.getLocation())) return;
-		if(player.getGameMode() != GameMode.CREATIVE) {
+		if(!player.getAllowFlight()) {
 			player.setAllowFlight(false);
 			player.setFlying(false);
 		}
@@ -127,8 +128,17 @@ public class PlayerListener extends Module {
 			}
 		}, 3L);
 	}
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onDeath(PlayerDeathEvent event) {
+		Player player = event.getEntity();
 
-	@EventHandler(priority = EventPriority.HIGH)
+		if (player.getAllowFlight()) {
+			player.setAllowFlight(false);
+			player.setFlying(false);
+		}
+	}
+
+    @EventHandler(priority = EventPriority.HIGH)
 	public void onPlayerQuit(PlayerQuitEvent event) {
 
 		Player player = event.getPlayer();

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/player/PlayerListener.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/player/PlayerListener.java
@@ -139,6 +139,8 @@ public class PlayerListener extends Module {
 		}
 
 		FlyCommand.allowPlayerFly.remove(player.getUniqueId());
+		player.setAllowFlight(false);
+		player.setFlying(false);
 
 		player.getActivePotionEffects().forEach(effect -> player.removePotionEffect(effect.getType()));
 

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/player/PlayerListener.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/player/PlayerListener.java
@@ -10,6 +10,7 @@ import fun.lewisdev.deluxehub.utility.TextUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
+import org.bukkit.GameMode;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Firework;
 import org.bukkit.entity.Player;
@@ -87,7 +88,10 @@ public class PlayerListener extends Module {
 	public void onPlayerJoin(PlayerJoinEvent event) {
 		Player player = event.getPlayer();
 		if (inDisabledWorld(player.getLocation())) return;
-
+		if(player.getGameMode() != GameMode.CREATIVE) {
+			player.setAllowFlight(false);
+			player.setFlying(false);
+		}
 		// Join message handling
 		if (joinQuitMessagesEnabled) {
 			if (joinMessage.equals("")) event.setJoinMessage(null);
@@ -139,9 +143,6 @@ public class PlayerListener extends Module {
 		}
 
 		FlyCommand.allowPlayerFly.remove(player.getUniqueId());
-		player.setAllowFlight(false);
-		player.setFlying(false);
-
 		player.getActivePotionEffects().forEach(effect -> player.removePotionEffect(effect.getType()));
 
 	}


### PR DESCRIPTION

Previously, flight was only removed from the tracking map but not disabled for the player. This required executing /fly twice to disable it. Now, flight is correctly turned off when a player leaves. 

Also some errors were shown when playing sounds, which have been fixed.

It has been tested in the newest version, and it works as intended.
