### PR TITLE
Fix: Add permission check for fly on gamemode change

### DIFF
--- a/src/main/java/dev/strafbefehl/deluxehubreloaded/action/actions/GamemodeAction.java
+++ b/src/main/java/dev/strafbefehl/deluxehubreloaded/action/actions/GamemodeAction.java
@@ -18,9 +18,8 @@ public class GamemodeAction implements Action {
 		try {
 			player.setGameMode(GameMode.valueOf(data.toUpperCase()));
 			if (player.getGameMode() == GameMode.ADVENTURE || player.getGameMode() == GameMode.SURVIVAL) {
-				if (player.hasPermission("deluxehub.command.fly")) {
-					player.getPlayer().setAllowFlight(true);
-				}
+				boolean enableFly = player.hasPermission("deluxehub.command.fly");
+				player.getPlayer().setAllowFlight(enableFly);
 			}
 		} catch (IllegalArgumentException ex) {
 			Bukkit.getLogger().warning("[DeluxeHubReloaded Action] Invalid gamemode name: " + data.toUpperCase());

--- a/src/main/java/dev/strafbefehl/deluxehubreloaded/action/actions/GamemodeAction.java
+++ b/src/main/java/dev/strafbefehl/deluxehubreloaded/action/actions/GamemodeAction.java
@@ -18,7 +18,9 @@ public class GamemodeAction implements Action {
 		try {
 			player.setGameMode(GameMode.valueOf(data.toUpperCase()));
 			if (player.getGameMode() == GameMode.ADVENTURE || player.getGameMode() == GameMode.SURVIVAL) {
-				player.getPlayer().setAllowFlight(true);
+				if (player.hasPermission("deluxehub.command.fly")) {
+					player.getPlayer().setAllowFlight(true);
+				}
 			}
 		} catch (IllegalArgumentException ex) {
 			Bukkit.getLogger().warning("[DeluxeHubReloaded Action] Invalid gamemode name: " + data.toUpperCase());


### PR DESCRIPTION
* Added a permission check for `"deluxehub.command.fly"` before enabling flight for players in Adventure or Survival gamemodes in `GamemodeAction.java`.


_P.S: If needed, this can be moved to a separate configuration file._
